### PR TITLE
chore: update Directory.Build.props to improve CI conditions and clea…

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -2,13 +2,12 @@
   <!-- Shared properties for all projects in the solution -->
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
-    <RuntimeFrameworkVersion>8.0.11</RuntimeFrameworkVersion> <!-- Latest secure version -->
+    <RuntimeFrameworkVersion>8.0.11</RuntimeFrameworkVersion>
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
 
     <!-- License Information -->
     <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
     <PackageIcon>icon.png</PackageIcon>
-    <PackageIconUrl>https://raw.githubusercontent.com/agenixframework/agenix/master/.assets/icons/icon.png</PackageIconUrl>
     <Copyright>Copyright (c) 2025 Agenix</Copyright>
 
     <!-- Author Information -->
@@ -43,66 +42,59 @@
     <!-- Build Properties -->
     <GenerateAssemblyInfo>true</GenerateAssemblyInfo>
     <Deterministic>true</Deterministic>
-    <ContinuousIntegrationBuild Condition="'$(GITHUB_ACTIONS)' == 'true'">true</ContinuousIntegrationBuild>
     <DebugType>portable</DebugType>
     <DebugSymbols>true</DebugSymbols>
 
+    <!-- Enable CI build for Release builds or CI environments -->
+    <ContinuousIntegrationBuild Condition="'$(Configuration)' == 'Release' OR '$(GITHUB_ACTIONS)' == 'true' OR '$(CI)' == 'true'">true</ContinuousIntegrationBuild>
   </PropertyGroup>
 
   <!-- Source Projects -->
-    <PropertyGroup Condition="!$(MSBuildProjectName.EndsWith('.Tests'))">
-      <GenerateDocumentationFile>true</GenerateDocumentationFile>
-      <IsPackable>true</IsPackable>
-    </PropertyGroup>
+  <PropertyGroup Condition="!$(MSBuildProjectName.EndsWith('.Tests'))">
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <IsPackable>true</IsPackable>
+  </PropertyGroup>
 
-    <!-- Test Projects -->
-    <PropertyGroup Condition="$(MSBuildProjectName.EndsWith('.Tests'))">
-      <IsPackable>false</IsPackable>
-      <IsTestProject>true</IsTestProject>
-    </PropertyGroup>
+  <!-- Test Projects -->
+  <PropertyGroup Condition="$(MSBuildProjectName.EndsWith('.Tests'))">
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+  </PropertyGroup>
 
-    <!-- Common Package References for Tests -->
-    <ItemGroup Condition="$(MSBuildProjectName.EndsWith('.Tests'))">
-      <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.0" />
-      <PackageReference Include="NUnit" Version="4.3.2" />
-      <PackageReference Include="NUnit3TestAdapter" Version="5.0.0" />
-      <PackageReference Include="NSubstitute" Version="5.3.0" />
-      <PackageReference Include="coverlet.collector" Version="6.0.0">
-        <PrivateAssets>all</PrivateAssets>
-        <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
-      </PackageReference>
+  <!-- Common Package References for Tests -->
+  <ItemGroup Condition="$(MSBuildProjectName.EndsWith('.Tests'))">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.0" />
+    <PackageReference Include="NUnit" Version="4.3.2" />
+    <PackageReference Include="NUnit3TestAdapter" Version="5.0.0" />
+    <PackageReference Include="NSubstitute" Version="5.3.0" />
+    <PackageReference Include="coverlet.collector" Version="6.0.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
 
-      <!-- Security fixes for vulnerable packages -->
-          <PackageVersion Include="System.Formats.Asn1" Version="8.0.1" />
-          <PackageVersion Include="System.Text.Json" Version="8.0.5" />
-          <PackageVersion Include="System.Net.Http" Version="4.3.4" />
-          <PackageVersion Include="System.Security.Cryptography.X509Certificates" Version="4.3.2" />
-          <PackageVersion Include="System.Data.SqlClient" Version="4.8.6" />
+  <!-- Security fixes for vulnerable packages -->
+  <ItemGroup>
+    <PackageVersion Include="System.Formats.Asn1" Version="8.0.1" />
+    <PackageVersion Include="System.Text.Json" Version="8.0.5" />
+    <PackageVersion Include="System.Net.Http" Version="4.3.4" />
+    <PackageVersion Include="System.Security.Cryptography.X509Certificates" Version="4.3.2" />
+    <PackageVersion Include="System.Data.SqlClient" Version="4.8.6" />
+  </ItemGroup>
 
-    </ItemGroup>
+  <!-- Source Link Package Reference -->
+  <ItemGroup>
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />
+  </ItemGroup>
 
-  <!-- Include LICENSE file in packages -->
+  <!-- Include LICENSE and README files in packages -->
   <ItemGroup>
     <None Include="$(MSBuildThisFileDirectory)LICENSE" Pack="true" PackagePath="LICENSE" Visible="false" />
     <None Include="$(MSBuildThisFileDirectory)README.md" Pack="true" PackagePath="README.md" Visible="false" Condition="Exists('$(MSBuildThisFileDirectory)README.md')" />
   </ItemGroup>
 
-  <!-- Source Link Package Reference -->
-    <ItemGroup>
-      <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />
-    </ItemGroup>
-
-    <!-- Include Icons in All Packages -->
-      <ItemGroup>
-        <!-- Main package icon (required by NuGet) -->
-        <None Include="$(MSBuildThisFileDirectory).assets/icons/icon.png" Pack="true" PackagePath="icon.png" Link="icon.png" />
-
-        <!-- Additional icon sizes -->
-        <None Include="$(MSBuildThisFileDirectory).assets/icons/icon-16.png" Pack="true" PackagePath="icons/" Link="icons/icon-16.png" />
-        <None Include="$(MSBuildThisFileDirectory).assets/icons/icon-32.png" Pack="true" PackagePath="icons/" Link="icons/icon-32.png" />
-        <None Include="$(MSBuildThisFileDirectory).assets/icons/icon-64.png" Pack="true" PackagePath="icons/" Link="icons/icon-64.png" />
-        <None Include="$(MSBuildThisFileDirectory).assets/icons/icon-128.png" Pack="true" PackagePath="icons/" Link="icons/icon-128.png" />
-        <None Include="$(MSBuildThisFileDirectory).assets/icons/icon.svg" Pack="true" PackagePath="icons/" Link="icons/icon.svg" />
-      </ItemGroup>
-
+  <!-- Include Icons in All Packages -->
+  <ItemGroup>
+    <None Include="$(MSBuildThisFileDirectory).assets/icons/icon.png" Pack="true" PackagePath="icon.png" Link="icon.png" />
+  </ItemGroup>
 </Project>


### PR DESCRIPTION
…n redundant properties

- Refined `ContinuousIntegrationBuild` property to support CI environments and release builds
- Removed unused `PackageIconUrl` property
- Simplified XML structure for better readability
- Consolidated properties and item groups for clarity and maintainability