### PR TITLE
feat(playwright): add storage state management and auto-save support

### DIFF
--- a/Agenix.Playwright/Endpoint/PlaywrightBrowser.cs
+++ b/Agenix.Playwright/Endpoint/PlaywrightBrowser.cs
@@ -1044,7 +1044,7 @@ public class PlaywrightBrowser : AbstractEndpoint, IProducer
         }
     }
 
-    private static async Task CleanupResources(string contextId, IBrowserContext context,
+    private async Task CleanupResources(string contextId, IBrowserContext context,
         List<(string pageId, IPage page)> pages)
     {
         try
@@ -1054,6 +1054,20 @@ public class PlaywrightBrowser : AbstractEndpoint, IProducer
             {
                 try
                 {
+                    // Auto-save storage state if enabled and path is configured
+                    if (_endpointConfiguration.AutoSaveStorageState &&
+                        !string.IsNullOrEmpty(_endpointConfiguration.StorageStatePath))
+                    {
+                        Log.LogDebug("Auto-saving storage state to: {StorageStatePath}", _endpointConfiguration.StorageStatePath);
+
+                        await context.StorageStateAsync(new BrowserContextStorageStateOptions
+                        {
+                            Path = _endpointConfiguration.StorageStatePath
+                        });
+
+                        Log.LogInformation("Storage state automatically saved to: {StorageStatePath}", _endpointConfiguration.StorageStatePath);
+                    }
+
                     await p.page.CloseAsync();
                 }
                 catch (Exception ex)
@@ -1205,6 +1219,18 @@ public class PlaywrightBrowser : AbstractEndpoint, IProducer
             {
                 contextOptions.RecordVideoSize = _endpointConfiguration.VideoSize;
             }
+        }
+
+        // Set storage state path (most common - file-based)
+        if (!string.IsNullOrEmpty(_endpointConfiguration.StorageStatePath))
+        {
+            contextOptions.StorageStatePath = _endpointConfiguration.StorageStatePath;
+        }
+
+        // Set raw storage state content (alternative approach)
+        if (!string.IsNullOrEmpty(_endpointConfiguration.StorageState))
+        {
+            contextOptions.StorageState = _endpointConfiguration.StorageState;
         }
     }
 

--- a/Agenix.Playwright/Endpoint/PlaywrightBrowserConfiguration.cs
+++ b/Agenix.Playwright/Endpoint/PlaywrightBrowserConfiguration.cs
@@ -72,7 +72,7 @@ public class PlaywrightBrowserConfiguration : AbstractEndpointConfiguration
     /// <summary>
     ///     Viewport settings
     /// </summary>
-    public ViewportSize? Viewport { get; set; } = ViewportSize.NoViewport;
+    public ViewportSize? Viewport { get; set; } = new() { Width = 1920, Height = 1080 };
 
     /// <summary>
     ///     Default timeout for page operations in milliseconds
@@ -88,6 +88,21 @@ public class PlaywrightBrowserConfiguration : AbstractEndpointConfiguration
     ///     Ignore HTTPS errors
     /// </summary>
     public bool IgnoreHttpsErrors { get; set; }
+
+    /// <summary>
+    /// Path to storage state file for context persistence
+    /// </summary>
+    public string? StorageStatePath { get; set; }
+
+    /// <summary>
+    /// Raw storage state JSON content
+    /// </summary>
+    public string? StorageState { get; set; }
+
+    /// <summary>
+    /// Automatically save storage state when context is disposed
+    /// </summary>
+    public bool AutoSaveStorageState { get; set; } = false;
 
     /// <summary>
     ///     Enable JavaScript

--- a/Agenix.Screenplay/Cast/Stage.cs
+++ b/Agenix.Screenplay/Cast/Stage.cs
@@ -95,4 +95,12 @@ public class Stage
     {
         return _actorInTheSpotlight != null;
     }
+
+    /// <summary>
+    /// Gets the list of actors currently present on the stage.
+    /// </summary>
+    /// <value>
+    /// A read-only list of <see cref="Actor"/> instances representing the performers currently active in the screenplay test.
+    /// </value>
+    public IReadOnlyList<Actor> Actors => _cast.GetActors();
 }


### PR DESCRIPTION
Introduced properties for configuring storage state paths and raw content in browser contexts. Implemented auto-save storage state functionality during context disposal and updated resource cleanup with support for saving state automatically.